### PR TITLE
Add support for Default TTL and Shield

### DIFF
--- a/libraries/provider_fastly_backend.rb
+++ b/libraries/provider_fastly_backend.rb
@@ -72,6 +72,13 @@ class Chef
           new_resource.updated_by_last_action(true)
         end
 
+        unless backend.shield == new_resource.shield
+          backend.shield = new_resource.shield
+          fastly_client.update_backend(backend)
+          backend.save!
+          Chef::Log.info "#{ @new_resource } shield updated."
+          new_resource.updated_by_last_action(true)
+        end
       end
 
       def backend

--- a/libraries/provider_fastly_request_setting.rb
+++ b/libraries/provider_fastly_request_setting.rb
@@ -99,6 +99,12 @@ class Chef
           new_resource.updated_by_last_action(true)
         end
 
+        unless request_setting.default_ttl == new_resource.default_ttl
+          request_setting.default_ttl = new_resource.default_ttl
+          request_setting.save!
+          Chef::Log.info "#{ @new_resource } default_ttl updated."
+          new_resource.updated_by_last_action(true)
+        end
       end
 
       def request_setting

--- a/libraries/resource_fastly_backend.rb
+++ b/libraries/resource_fastly_backend.rb
@@ -33,6 +33,39 @@ class Chef
       attribute :ssl, kind_of: [TrueClass, FalseClass], default: false
       attribute :address, kind_of: String, name_attribute: true, required: true
       attribute :auto_loadbalance, kind_of: [TrueClass, FalseClass], default: false
+      attribute :shield, kind_of: String, equal_to: DATACENTERS
+
+      DATACENTERS = [
+        "Amsterdam",
+        "Ashburn",
+        "Atlanta",
+        "Auckland",
+        "Brisbane",
+        "Boston",
+        "Chicago",
+        "Dallas",
+        "Denver",
+        "Fujairah Al Mahta",
+        "Frankfurt",
+        "Hong Kong",
+        "London - LCY",
+        "London - LHR",
+        "Los Angeles",
+        "Toronto",
+        "Melbourne",
+        "Miami",
+        "New York City",
+        "Osaka",
+        "Perth",
+        "San Jose",
+        "Seattle",
+        "Singapore",
+        "Stockholm",
+        "Sydney",
+        "Tokyo",
+        "Wellington",
+        "Sao Paulo",
+      ].freeze
 
     end
   end

--- a/libraries/resource_fastly_request_setting.rb
+++ b/libraries/resource_fastly_request_setting.rb
@@ -32,6 +32,7 @@ class Chef
       attribute :force_miss, kind_of: [TrueClass, FalseClass], default: nil
       attribute :bypass_busy_wait, kind_of: [TrueClass, FalseClass], default: nil
       attribute :default_host, kind_of: String, default: nil
+      attribute :default_ttl, kind_of: Integer, default 3600
       attribute :hash_keys, kind_of: String, default: nil
       attribute :max_stale_age, kind_of: Integer, default: nil
       attribute :request_action, kind_of: String, default: nil, equal_to: ['pass', 'lookup']


### PR DESCRIPTION
This is a GitHub PR for the moment as I am having issues with delivery-cli.

This adds support for setting the Default TTL for a given project, and adds support for Fastly Shielding.

There is one thing which is missing from the shielding support which is dynamic POP name validation. While the fastly API exposes a REST endpoint to obtain a list of valid datacenter names, which is actually what I used to generate the constant, the endpoint does not currently exist in the fastly-ruby gem. https://docs.fastly.com/api/tools#datacenter
