### PR TITLE
add fastly_acl resource

### DIFF
--- a/libraries/provider_fastly_acl.rb
+++ b/libraries/provider_fastly_acl.rb
@@ -1,0 +1,66 @@
+#
+# Author:: Patrick Wright (<patrick@chef.io>)
+# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/provider/lwrp_base'
+require_relative 'provider_fastly_base'
+
+class Chef
+  class Provider
+    class FastlyACL < Chef::Provider::FastlyBase
+
+      action :create do
+        if acl.nil?
+          create_acl
+          Chef::Log.info "#{new_resource} ACL created."
+          new_resource.updated_by_last_action(true)
+        else
+          Chef::Log.debug "ACL exists."
+        end
+
+        entries_to_delete = entries.select { |entry| !new_resource.entries.include?(entry.ip) }
+
+        entries.each do |entry| 
+          if new_resource.entries.include?(entry.ip)
+            Chef::Log.debug "ACL entry '#{entry.ip}' exists."
+          elsif entries_to_delete.include?(entry.ip)
+            acl.delete_entry(entry)
+            Chef::Log.info "ACL entry '#{entry.ip}' deleted."
+            new_resource.updated_by_last_action(true)
+          else
+            acl.create_entry(ip: entry.ip)
+            Chef::Log.info "ACL entry '#{entry.ip}' created."
+            new_resource.updated_by_last_action(true)
+          end
+        end
+      end
+
+      def acl
+        @acl ||= fastly_client.list_acls.find { |acl| acl.name == new_resource.name }
+      end
+
+      def entries
+        @entries ||= acl.list_entries
+      end
+
+      def create_acl
+        fastly_client.create_acl(name: new_resource.name)
+      end
+
+    end
+  end
+end

--- a/libraries/resource_fastly_acl.rb
+++ b/libraries/resource_fastly_acl.rb
@@ -1,0 +1,42 @@
+#
+# Author:: Patrick Wright (<patrick@chef.io>)
+# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'chef/resource/lwrp_base'
+require_relative 'resource_fastly_base'
+
+class Chef
+  class Resource
+    class FastlyACL < Chef::Resource::FastlyBase
+
+      self.resource_name = :fastly_acl
+      actions :create
+      default_action :create
+
+      attribute :entries, kind_of: Array, required: true, callbacks: {
+        "entries must be an array of valid ip addresses as strings" => proc do |entries|
+          entries.all? { |entry| (entry.is_a?(String) && self.valid_ip?(entry)) }
+        end
+      }
+
+      def self.valid_ip?(ip)
+        ip =~ /^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
+      end
+
+    end
+  end
+end

--- a/spec/unit/libraries/provider_fastly_acl_spec.rb
+++ b/spec/unit/libraries/provider_fastly_acl_spec.rb
@@ -1,0 +1,91 @@
+#
+# Author:: Patrick Wright (<patrick@chef.io>)
+# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'libraries/provider_fastly_acl'
+require 'libraries/resource_fastly_acl'
+
+describe Chef::Provider::FastlyACL do
+  before(:each) do
+    @node = Chef::Node.new
+    @events = Chef::EventDispatch::Dispatcher.new
+    @run_context = Chef::RunContext.new(@node, {}, @events)
+    @new_resource = Chef::Resource::FastlyACL.new('acl_name')
+    @current_resource = Chef::Resource::FastlyACL.new('acl_name')
+    @provider = Chef::Provider::FastlyACL.new(@new_resource, @run_context)
+    @provider.current_resource = @current_resource
+  end
+
+  describe '#acl' do
+    before(:each) do
+      @new_resource.api_key('an_api_key')
+      @new_resource.service('service_name')
+
+      allow(@provider.fastly_client).to receive(:list_services) \
+        .and_return([
+          double(Fastly::Service,
+           name: 'service_name',
+           id: '1234abc',
+           version: double(Fastly::Version, number: 10)
+          ),
+          double(Fastly::Service, name: 'another_service', id: 'cba4321'),
+        ])
+
+      allow(@provider.fastly_client).to receive(:list_acls) \
+        .and_return([
+          double(Fastly::ACL, name: 'acl_group'),
+          double(Fastly::ACL, name: 'acl_group_2'),
+        ])
+    end
+
+    it 'returns acl object if acl name matches' do
+      @new_resource.name('acl_group')
+      expect(@provider.acl.name).to eq('acl_group')
+    end
+
+    it 'returns nil if acl is not found' do
+      @new_resource.name('not-found')
+      expect(@provider.acl).to eq(nil)
+    end
+  end
+
+  describe '#create_acl' do
+    before(:each) do
+      @new_resource.api_key('an_api_key')
+      @new_resource.service('service_name')
+      @new_resource.entries(['0.0.0.0'])
+
+      allow(@provider.fastly_client).to receive(:list_services) \
+        .and_return([
+          double(Fastly::Service,
+           name: 'service_name',
+           id: '1234abc',
+           version: double(Fastly::Version, number: 10)
+          ),
+          double(Fastly::Service, name: 'another_service', id: 'cba4321'),
+      ])
+
+      allow(@provider.fastly_client).to receive(:create_acl) \
+        .and_return(double(Fastly::ACL, name: 'acl_group'))
+    end
+
+    it 'should return a acl object when created' do
+      expect(@provider.create_acl.name).to eq('acl_group')
+    end
+  end
+end

--- a/spec/unit/libraries/resource_fastly_acl_spec.rb
+++ b/spec/unit/libraries/resource_fastly_acl_spec.rb
@@ -1,0 +1,44 @@
+#
+# Author:: Patrick Wright (<patrick@chef.io>)
+# Copyright:: Copyright (c) 2016 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'libraries/resource_fastly_acl'
+
+describe Chef::Resource::FastlyACL do
+
+  before(:each) do
+    @resource = Chef::Resource::FastlyACL.new('acl_name')
+  end
+
+  it "should set the entries" do
+    expect(@resource.entries(['1.2.3.4'])).to eq(['1.2.3.4'])
+  end
+
+  it 'should raise validation error when not passed an array' do
+    expect { @resource.entries('foo') }.to raise_error Chef::Exceptions::ValidationFailed
+  end
+
+  it 'should raise validation error when not passed valid string in the array' do
+    expect { @resource.entries([1]) }.to raise_error Chef::Exceptions::ValidationFailed
+  end
+
+  it 'should raise validation error when not passed a valid ip' do
+    expect { @resource.entries(['256.0.0.0']) }.to raise_error Chef::Exceptions::ValidationFailed
+  end
+
+end


### PR DESCRIPTION
We are adding the ACL resource to replace the IP block list process we have using conditions.

Just a few basic specs right now. I will be adding more this week (chefspec). I figured this would be a good place to start review.

IP entries will be added, deleted or left alone based on the entries found for the named ACL.

``` ruby
fastly_acl "acl_group" do
  entries %w(
   1.2.3.4
   5.6.7.8
  )
end
```

Signed-off-by: Patrick Wright patrick@chef.io

@chef-cookbooks/engineering-services @chef-cookbooks/cia 
